### PR TITLE
Remove an erroneous .done()

### DIFF
--- a/hangouts.js
+++ b/hangouts.js
@@ -218,7 +218,7 @@ module.exports = function(RED) {
 				node.log("Message successfully send.");
 			}).catch(function(error) {
 				node.error(error);
-			}).done();
+			});
 
 			node.on("close", function(){
 				node.config.removeListener("status", node.refreshStatus);


### PR DESCRIPTION
Don't know how i could have missed that...
.done() is not a standard promise function so it does not exists.
Leftover from before msg.links/msg.image
